### PR TITLE
Do not error if the labscript suite profile dir exists.

### DIFF
--- a/labscript_profile/create.py
+++ b/labscript_profile/create.py
@@ -2,8 +2,8 @@ import sys
 import os
 import shutil
 import configparser
+from pathlib import Path
 from labscript_profile import LABSCRIPT_SUITE_PROFILE, default_labconfig_path
-
 
 _here = os.path.dirname(os.path.abspath(__file__))
 DEFAULT_PROFILE_CONTENTS = os.path.join(_here, 'default_profile')
@@ -30,14 +30,29 @@ def make_labconfig_file():
         config.set('programs', 'text_editor_arguments', '-a TextEdit {file}')
     if sys.platform != 'win32':
         config.set('programs', 'hdf5_viewer', 'hdfview')
-        config.set('DEFAULT', 'shared_drive', '$HOME/labscript_shared')
+        config.set('DEFAULT', 'shared_drive', str(Path.home() / ' labscript_shared'))
 
     with open(target_path, 'w') as f:
         config.write(f)
 
 
 def create_profile():
-    if os.path.exists(LABSCRIPT_SUITE_PROFILE):
-        raise FileExistsError(LABSCRIPT_SUITE_PROFILE)
-    shutil.copytree(DEFAULT_PROFILE_CONTENTS, LABSCRIPT_SUITE_PROFILE)
+    src = Path(DEFAULT_PROFILE_CONTENTS)
+    dest = Path(LABSCRIPT_SUITE_PROFILE)
+    # Profile directory may exist already, but we will error if it contains any of the
+    # files or directories we want to copy into it:
+    os.makedirs(dest, exist_ok=True)
+    # Preferable to raise errors if anything exists before copying anything, rather than
+    # do a partial copy before hitting an error:
+    for src_file in src.iterdir():
+        dest_file = dest / src_file.name
+        if dest_file.exists():
+            raise FileExistsError(dest_file)
+    for src_file in src.iterdir():
+        dest_file = dest / src_file.name
+        if src_file.is_dir():
+            shutil.copytree(src_file, dest_file)
+        else:
+            shutil.copy2(src_file, dest_file)
+
     make_labconfig_file()


### PR DESCRIPTION
Still errors if any of its contents exist, however.

This allows developers to use the labscript profile directory as their
development space if they like.

Also fix failure to use actual home directory in default shared drive
path in Unix (a literal '$HOME' string was used instead).

Closes #37