### PR TITLE
Declarative setup

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@ keywords = experiment control automation
 license = BSD
 classifiers =
     License :: OSI Approved :: BSD License
-    Programming Language :: Python :: 2.7
+    Programming Language :: Python :: 3 :: Only
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
@@ -23,7 +23,7 @@ classifiers =
 zip_safe = False
 include_package_data = True
 packages = labscript_utils, labscript_profile
-python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5
+python_requires = >=3.6
 install_requires =
   importlib_metadata>=1.0 ; python_version<'3.8'
   h5py>=2.9

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,5 +44,3 @@ console_scripts =
 
 [dist_conda]
 pythons = 3.6, 3.7, 3.8
-platforms = linux-64,win-32,win-64,osx-64
-force_conversion = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,48 @@
+[metadata]
+name = labscript_utils
+description = Shared utilities for the labscript suite
+long_description = file: README.md
+long_description_content_type = text/markdown
+author = The labscript suite community
+author_email = labscriptsuite@googlegroups.com
+url = http://labscriptsuite.org
+project_urls = 
+    Source Code=https://github.com/labscript-suite/labscript-utils
+    Download=https://github.com/labscript-suite/labscript-utils/releases
+    Tracker=https://github.com/labscript-suite/labscript-utils/issues
+keywords = experiment control automation
+license = BSD
+classifiers =
+    License :: OSI Approved :: BSD License
+    Programming Language :: Python :: 2.7
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+
+[options]
+zip_safe = False
+include_package_data = True
+packages = labscript_utils, labscript_profile
+python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5
+install_requires =
+  importlib_metadata>=1.0 ; python_version<'3.8'
+  h5py>=2.9
+  numpy>=1.15
+  pyqtgraph>=0.11.0rc0 ; python_version>='3.8'
+  pyqtgraph ; python_version<'3.8'
+  pywin32 ; sys_platform=='win32'
+  qtutils>=2.2.3
+  scipy
+  setuptools_scm
+  zprocess>=2.18.0
+setup_requires =
+  setuptools_scm
+
+[options.entry_points]
+console_scripts =
+  labscript-profile-create = labscript_profile.create:create_profile
+
+[dist_conda]
+pythons = 3.6, 3.7, 3.8
+platforms = linux-64,win-32,win-64,osx-64
+force_conversion = True

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 import os
 from setuptools import setup
-from setuptools.dist import Distribution
 
 try:
     from setuptools_conda import dist_conda

--- a/setup.py
+++ b/setup.py
@@ -1,107 +1,40 @@
-# USAGE NOTES
-#
-# Make a PyPI release tarball with:
-#
-#     python setup.py sdist
-#
-# Upload to test PyPI with:
-#
-#     twine upload --repository-url https://test.pypi.org/legacy/ dist/*
-#
-# Install from test PyPI with:
-#
-#     pip install --index-url https://test.pypi.org/simple/ labscript_utils
-#
-# Upload to real PyPI with:
-#
-#     twine upload dist/*
-#
-# Build conda packages for all platforms (in a conda environment with setuptools_conda
-# installed) with:
-#
-#     python setup.py dist_conda
-#
-# Upoad to your own account (for testing) on anaconda cloud (in a conda environment with
-# anaconda-client installed) with:
-#
-#     anaconda upload --skip-existing conda_packages/*/*
-#
-# (Trickier on Windows, as it won't expand the wildcards)
-#
-# Upoad to the labscript-suite organisation's channel on anaconda cloud (in a
-# conda environment with anaconda-client installed) with:
-#
-#     anaconda  upload -u labscript-suite --skip-existing conda_packages/*/*
-#
-# If you need to rebuild the same version of the package for conda due to a packaging
-# issue, you must increment CONDA_BUILD_NUMBER in order to create a unique version on
-# anaconda cloud. When subsequently releasing a new version of the package,
-# CONDA_BUILD_NUMBER should be reset to zero.
-
 import os
 from setuptools import setup
 from distutils import sysconfig
 
 try:
     from setuptools_conda import dist_conda
+
+    CMDCLASS = {"dist_conda": dist_conda}
 except ImportError:
-    dist_conda = None
+    CMDCLASS = {}
 
-SETUP_REQUIRES = ['setuptools', 'setuptools_scm']
-
-INSTALL_REQUIRES = [
-    "setuptools_scm",
-    "importlib_metadata >=1.0;      python_version < '3.8'",
-    "pywin32;                       sys_platform == 'win32'",
-    "numpy >=1.15",
-    "scipy",
-    "h5py >=2.9",
-    "qtutils >=2.2.3",
-    "zprocess >=2.18.0",
-    "pyqtgraph >=0.11.0rc0;         python_version >= '3.8'",
-    "pyqtgraph;                     python_version < '3.8'",
-]
-
-if 'CONDA_BUILD' in os.environ:
+if "CONDA_BUILD" in os.environ:
     # Various packaging schemes are variously unhappy with how to include the .pth file
     # in site-packages. Conda is happy if we specify it with data_files and an absolute
     # path, whereas basically everything else (pip, setup.py install, bdist,
     # bdist_wheel) is happy if we specify it as package_data one level up.
-    data_files = [(sysconfig.get_python_lib(), ['labscript-suite.pth'])]
-    package_data = {}
+    DATA_FILES = [(sysconfig.get_python_lib(), ["labscript-suite.pth"])]
+    PACKAGE_DATA = {}
 else:
-    data_files = []
-    package_data = {'labscript_suite': [os.path.join('..', 'labscript-suite.pth')]}
+    DATA_FILES = []
+    PACKAGE_DATA = {"labscript_suite": [os.path.join("..", "labscript-suite.pth")]}
+
+VERSION_SCHEME = {}
+VERSION_SCHEME["version_scheme"] = os.environ.get(
+    "SCM_VERSION_SCHEME", "guess-next-dev"
+)
+VERSION_SCHEME["local_scheme"] = os.environ.get("SCM_LOCAL_SCHEME", "node-and-date")
+
+VERSION_SCHEME = {}
+VERSION_SCHEME["version_scheme"] = os.environ.get(
+    "SCM_VERSION_SCHEME", "release-branch-semver"
+)
+VERSION_SCHEME["local_scheme"] = os.environ.get("SCM_LOCAL_SCHEME", "node-and-date")
 
 setup(
-    name='labscript_utils',
-    use_scm_version=True,
-    description="Shared utilities for the labscript suite",
-    long_description=open('README.md').read(),
-    long_description_content_type='text/markdown',
-    author='The labscript suite community',
-    author_email='labscriptsuite@googlegroups.com ',
-    url='http://labscriptsuite.org',
-    license="BSD",
-    packages=["labscript_utils", "labscript_profile"],
-    zip_safe=False,
-    setup_requires=SETUP_REQUIRES,
-    include_package_data=True,
-    package_data=package_data,
-    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5",
-    install_requires=INSTALL_REQUIRES if 'CONDA_BUILD' not in os.environ else [],
-    cmdclass={'dist_conda': dist_conda} if dist_conda is not None else {},
-    data_files=data_files,
-    entry_points={
-        'console_scripts': [
-            'labscript-profile-create = labscript_profile.create:create_profile',
-        ],
-    },
-    command_options={
-        'dist_conda': {
-            'pythons': (__file__, ['3.6', '3.7', '3.8']),
-            'platforms': (__file__, ['linux-64', 'win-32', 'win-64', 'osx-64']),
-            'force_conversion': (__file__, True),
-        },
-    },
+    use_scm_version=VERSION_SCHEME,
+    cmdclass=CMDCLASS,
+    data_files=DATA_FILES,
+    package_data=PACKAGE_DATA,
 )

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,9 @@
 import os
 from setuptools import setup
-from distutils import sysconfig
+from setuptools.dist import Distribution
 
 try:
     from setuptools_conda import dist_conda
-
     CMDCLASS = {"dist_conda": dist_conda}
 except ImportError:
     CMDCLASS = {}
@@ -20,17 +19,10 @@ else:
     DATA_FILES = []
     PACKAGE_DATA = {"labscript_suite": [os.path.join("..", "labscript-suite.pth")]}
 
-VERSION_SCHEME = {}
-VERSION_SCHEME["version_scheme"] = os.environ.get(
-    "SCM_VERSION_SCHEME", "guess-next-dev"
-)
-VERSION_SCHEME["local_scheme"] = os.environ.get("SCM_LOCAL_SCHEME", "node-and-date")
-
-VERSION_SCHEME = {}
-VERSION_SCHEME["version_scheme"] = os.environ.get(
-    "SCM_VERSION_SCHEME", "release-branch-semver"
-)
-VERSION_SCHEME["local_scheme"] = os.environ.get("SCM_LOCAL_SCHEME", "node-and-date")
+VERSION_SCHEME = {
+    "version_scheme": os.getenv("SCM_VERSION_SCHEME", "guess-next-dev"),
+    "local_scheme": os.getenv("SCM_LOCAL_SCHEME", "node-and-date"),
+}
 
 setup(
     use_scm_version=VERSION_SCHEME,


### PR DESCRIPTION
This PR introduces setup.cfg and makes setup.py as simple as possible, containing only programmatic overrides.

1. This allows setup.py to be identical (or near-identical) for all packages in the labscript suite.
1. Only additions in setup.cfg to existing configuration are:
   - Explicit `version_scheme` and `local_scheme` for setuptools_scm, overridden by environment variables `SCM_VERSION_SCHEME` and `SCM_LOCAL_SCHEME`, respectively, in anticipation of automated release process. (Default `version_scheme` will be updated to [`release-branch-semver`](pypa/setuptools_scm#430) upon next release of setuptools_scm.)
   - Added keywords and classifiers to metadata.
   - Added 'Source Code', 'Download', and (issue) 'Tracker' URLs to metadata to adorn PyPI sidebar.
1. Regarding building conda distributions, see chrisjbillington/setuptools_conda#1.