### PR TITLE
Remove code specific to building with setuptools_conda

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -38,9 +38,9 @@ install_requires =
 setup_requires =
   setuptools_scm
 
+[options.package_data]
+labscript_profile = ../labscript-suite.pth
+
 [options.entry_points]
 console_scripts =
   labscript-profile-create = labscript_profile.create:create_profile
-
-[dist_conda]
-pythons = 3.6, 3.7, 3.8

--- a/setup.py
+++ b/setup.py
@@ -1,32 +1,9 @@
 import os
 from setuptools import setup
-from distutils import sysconfig
-
-try:
-    from setuptools_conda import dist_conda
-    CMDCLASS = {"dist_conda": dist_conda}
-except ImportError:
-    CMDCLASS = {}
-
-if "CONDA_BUILD" in os.environ:
-    # Various packaging schemes are variously unhappy with how to include the .pth file
-    # in site-packages. Conda is happy if we specify it with data_files and an absolute
-    # path, whereas basically everything else (pip, setup.py install, bdist,
-    # bdist_wheel) is happy if we specify it as package_data one level up.
-    DATA_FILES = [(sysconfig.get_python_lib(), ["labscript-suite.pth"])]
-    PACKAGE_DATA = {}
-else:
-    DATA_FILES = []
-    PACKAGE_DATA = {"labscript_suite": [os.path.join("..", "labscript-suite.pth")]}
 
 VERSION_SCHEME = {
     "version_scheme": os.getenv("SCM_VERSION_SCHEME", "guess-next-dev"),
     "local_scheme": os.getenv("SCM_LOCAL_SCHEME", "node-and-date"),
 }
 
-setup(
-    use_scm_version=VERSION_SCHEME,
-    cmdclass=CMDCLASS,
-    data_files=DATA_FILES,
-    package_data=PACKAGE_DATA,
-)
+setup(use_scm_version=VERSION_SCHEME)


### PR DESCRIPTION
In the latest setuptools_conda, this is not necessary - the dist_conda
command is available without having to explicitly declare it in
setup.py, and the file path issue was sorted out by having
setuptools_conda build wheels as an intermediate, more closely matching
what a pip install does (this is the most commonly used way to build
conda packages anyway, so it's what setuptools_conda should have been
doing all along)

Also, setuptools_conda introspects python versions from package
classifiers, so that doesn't need to be declared.