### PR TITLE
Use standard method of getting own version.

### DIFF
--- a/labscript_utils/__init__.py
+++ b/labscript_utils/__init__.py
@@ -17,9 +17,7 @@ import traceback
 from pathlib import Path
 
 from .versions import get_version, NoVersionInfo
-__version__ = get_version(__name__, import_path=Path(__file__).parent.parent)
-if __version__ is NoVersionInfo:
-    __version__ = None
+from .__version__ import __version__ 
 
 PY2 = sys.version_info[0] == 2
 

--- a/labscript_utils/__version__.py
+++ b/labscript_utils/__version__.py
@@ -1,1 +1,21 @@
-__version__ = '2.16.0.dev3'
+import os
+from pathlib import Path
+try:
+    import importlib.metadata as importlib_metadata
+except ImportError:
+    import importlib_metadata
+
+VERSION_SCHEME = {
+    "version_scheme": os.getenv("SCM_VERSION_SCHEME", "guess-next-dev"),
+    "local_scheme": os.getenv("SCM_LOCAL_SCHEME", "node-and-date"),
+}
+
+root = Path(__file__).parent.parent
+if (root / '.git').is_dir():
+    from setuptools_scm import get_version
+    __version__ = get_version(root, **VERSION_SCHEME)
+else:
+    try:
+        __version__ = importlib_metadata.version(__package__)
+    except importlib_metadata.PackageNotFoundError:
+        __version__ = None


### PR DESCRIPTION
Even though the previous method was still self-contained, this is more standard.

using labscript_utils.versions to get its own version was even returning None in the case of an editable install. I'm not sure why, but now that we're removing a lot of the use of labscript_utils.versions, we can likely pare it back to something considerable less magical, so that it behaves more predictably.