### PR TITLE
Remove labscript_suite from default config file

### DIFF
--- a/labscript_profile/__init__.py
+++ b/labscript_profile/__init__.py
@@ -48,7 +48,7 @@ def add_userlib_and_pythonlib():
     time the interpreter starts up"""
     labconfig = default_labconfig_path()
     if labconfig is not None and labconfig.exists():
-        config = ConfigParser()
+        config = ConfigParser(defaults={'labscript_suite': LABSCRIPT_SUITE_PROFILE})
         config.read(labconfig)
         for option in ['userlib', 'pythonlib']:
             try:

--- a/labscript_profile/create.py
+++ b/labscript_profile/create.py
@@ -20,9 +20,8 @@ def make_labconfig_file():
         outfile.write(data)
 
     # Now change some things about it:
-    config = configparser.ConfigParser()
+    config = configparser.ConfigParser(interpolation=None)
     config.read(target_path)
-    config.set('DEFAULT', 'labscript_suite', str(LABSCRIPT_SUITE_PROFILE))
     if sys.platform in ['linux', 'linux2']:
         config.set('programs', 'text_editor', 'gedit')
     elif sys.platform == 'darwin':

--- a/labscript_profile/default_profile/labconfig/example.ini
+++ b/labscript_profile/default_profile/labconfig/example.ini
@@ -2,7 +2,6 @@
 experiment_name = default_experiment
 shared_drive = C:
 experiment_shot_storage = %(shared_drive)s\Experiments\%(experiment_name)s
-labscript_suite = C:\labscript_suite
 userlib=%(labscript_suite)s\userlib
 pythonlib = %(userlib)s\pythonlib
 labscriptlib = %(userlib)s\labscriptlib\%(experiment_name)s


### PR DESCRIPTION
But add it as a default option so that config files may continue to use
it as an interpolation value.

Saving config files whenever a value is set breaks this, as it actually
saves the default value to disk. Without adding a guard against it, it
actually writes any provided default values to disk before loading the
existing config file, actually wiping out the user's config completely.

So this commit removes the overridden methods that save back to disk.

No labscript code actually sets config values except for some code in
the BLACS plugins `__init__.py`, which adds the list of available
plugins. Not writing this back to disk is fine. If we ever make GUI
interfaces for manipulating the config file, it is poor form to just
overwrite the user's config file anyway, which may re-order sections and
remove comments. For that we would want to use something like
https://pypi.org/project/ConfigUpdater/.

Also simplify the code that gets the config path. There is only one
place on disk for config paths now, and if it doesn't exist the user
will get a FileNotFoundError with the full path, so I don't think there
is a strong need to wrap that error in one written by us that basically
says the same thing!

This change removes the hostname and config_prefix variables. These
variables are imported (unused) by lyse and runviewer, so I will remove
them from those projects. They are also imported and used by BLACS to
construct its config filepath. I will modify BLACS to instead put its
config file in the standard config file locations for apps.

Fixes #22