### PR TITLE
Make secure communication default

### DIFF
--- a/labscript_profile/default_profile/labconfig/example.ini
+++ b/labscript_profile/default_profile/labconfig/example.ini
@@ -52,3 +52,6 @@ integer_indexing = False
 autoload_config_file = %(app_saved_configs)s\runmanager\runmanager.ini
 output_folder_format = %%Y\%%m\%%d\{sequence_index:04d}
 filename_prefix_format = %%Y-%%m-%%d_{sequence_index:04d}_{script_basename}
+
+[security]
+shared_secret = %(labscript_suite)s\labconfig\zpsecret-b810f83f.key


### PR DESCRIPTION
Create a shared secret at profile creation time and add it to
labconfig. Raise an error if such an entry is not present, unless
allow_insecure is set instead.