### PR TITLE
Add `labconfig.{save,load}_appconfig()`

### DIFF
--- a/labscript_utils/labconfig.py
+++ b/labscript_utils/labconfig.py
@@ -106,7 +106,9 @@ def load_appconfig(filename):
     regardless of the written contents on the .ini file."""
     c = configparser.ConfigParser(interpolation=None)
     c.optionxform = str # preserve case
-    c.read(filename)
+    # No file? No config - don't crash.
+    if Path(filename).exists():
+        c.read(filename)
     return {
         section_name: {name: literal_eval(value) for name, value in section.items()}
         for section_name, section in c.items()

--- a/labscript_utils/labconfig.py
+++ b/labscript_utils/labconfig.py
@@ -10,9 +10,11 @@
 # for the full license.                                             #
 #                                                                   #
 #####################################################################
-import sys
 import os
 import configparser
+from ast import literal_eval
+from pprint import pformat
+from pathlib import Path
 
 from labscript_utils import dedent
 from labscript_profile import default_labconfig_path, LABSCRIPT_SUITE_PROFILE
@@ -69,3 +71,30 @@ class LabConfig(configparser.ConfigParser):
                 not have the required keys. Make sure the config file containes the
                 following structure:\n{self.file_format}"""
             raise Exception(dedent(msg))
+
+
+def save_appconfig(filename, data):
+    """Save a dictionary as an ini file. The keys of the dictionary comprise the section
+    names, and the values must themselves be dictionaries for the names and values
+    within each section. All section values will be converted to strings with
+    pprint.pformat()."""
+    data = {
+        section_name: {name: pformat(value) for name, value in section.items()}
+        for section_name, section in data.items()
+    }
+    c = configparser.ConfigParser(interpolation=None)
+    c.read_dict(data)
+    Path(filename).parent.mkdir(parents=True, exist_ok=True)
+    with open(filename, 'w') as f:
+        c.write(f)
+
+
+def load_appconfig(filename):
+    """Load an .ini file and return a dictionary of its contents. All values will be
+    converted to Python objects with ast.literal_eval()"""
+    c = configparser.ConfigParser(interpolation=None)
+    c.read(filename)
+    return {
+        section_name: {name: literal_eval(value) for name, value in section.items()}
+        for section_name, section in c.items()
+    }


### PR DESCRIPTION
These functions save a dict as an `.ini` file and load a dict from an
ini file, respectively. Strings are converted with `pprint.pformat` and
`ast.literal_eval`, which round-trip for standard Python datatypes.

These are the semantics presently used by apps (except BLACS) to save
their configs, but they use the `LabConfig` class to do so. Since #45
removed auto-saving of labconfig and auto creation of sections upon
setting a value (essentially it made labconfig read-only) apps using
labconfig to save data now may fail (labscript-suite/lyse#64).

Apps may instead use `save_appconfig()` to save data. They may continue
to use labconfig to load data as they are presently, but could be
simplified by using `load_appconfig()` instead.

This change doesn't modify the format of app config files and so is
backward compatible with existing config files.