### PR TITLE
Resolves #52

### DIFF
--- a/labscript_profile/default_profile/labconfig/example.ini
+++ b/labscript_profile/default_profile/labconfig/example.ini
@@ -1,12 +1,12 @@
 [DEFAULT]
-experiment_name = default_experiment
+apparatus_name = example_apparatus
 shared_drive = C:
-experiment_shot_storage = %(shared_drive)s\Experiments\%(experiment_name)s
-userlib=%(labscript_suite)s\userlib
+experiment_shot_storage = %(shared_drive)s\Experiments\%(apparatus_name)s
+userlib= %(labscript_suite)s\userlib
 pythonlib = %(userlib)s\pythonlib
-labscriptlib = %(userlib)s\labscriptlib\%(experiment_name)s
-analysislib = %(userlib)s\analysislib\%(experiment_name)s
-app_saved_configs = %(labscript_suite)s\app_saved_configs\%(experiment_name)s
+labscriptlib = %(userlib)s\labscriptlib\%(apparatus_name)s
+analysislib = %(userlib)s\analysislib\%(apparatus_name)s
+app_saved_configs = %(labscript_suite)s\app_saved_configs\%(apparatus_name)s
 user_devices = user_devices
 
 [paths]

--- a/labscript_utils/labconfig.py
+++ b/labscript_utils/labconfig.py
@@ -15,6 +15,7 @@ import configparser
 from ast import literal_eval
 from pprint import pformat
 from pathlib import Path
+import warnings
 
 from labscript_utils import dedent
 from labscript_profile import default_labconfig_path, LABSCRIPT_SUITE_PROFILE
@@ -62,13 +63,28 @@ class LabConfig(configparser.ConfigParser):
         # contains one string):
         self.read(config_path)
 
+        # Rename experiment_name to apparatus_name and raise a DeprectionWarning
+        experiment_name = self.get("DEFAULT", "experiment_name", fallback=None)
+        if experiment_name:
+            msg = """The experiment_name keyword has been renamed apparatus_name in
+                labscript_utils 3.0, and will be removed in a future version. Please
+                update your labconfig to use the apparatus_name keyword."""
+            warnings.warn(dedent(msg), FutureWarning)
+            if self.get("DEFAULT", "apparatus_name", fallback=None):
+                msg = """You have defined both experiment_name and apparatus_name in
+                    your labconfig. Please omit the deprecate experiment_name
+                    keyword."""
+                raise Exception(dedent(msg))
+            else:
+                self.set("DEFAULT", "apparatus_name", experiment_name)
+
         try:
             for section, options in required_params.items():
                 for option in options:
                     self.get(section, option)
         except configparser.NoOptionError:
             msg = f"""The experiment configuration file located at {config_path} does
-                not have the required keys. Make sure the config file containes the
+                not have the required keys. Make sure the config file contains the
                 following structure:\n{self.file_format}"""
             raise Exception(dedent(msg))
 
@@ -93,7 +109,7 @@ def save_appconfig(filename, data):
         for section_name, section in data.items()
     }
     c = configparser.ConfigParser(interpolation=None)
-    c.optionxform = str # preserve case
+    c.optionxform = str  # preserve case
     c.read_dict(data)
     Path(filename).parent.mkdir(parents=True, exist_ok=True)
     with open(filename, 'w') as f:
@@ -105,7 +121,7 @@ def load_appconfig(filename):
     converted to Python objects with ast.literal_eval(). All keys will be lowercase
     regardless of the written contents on the .ini file."""
     c = configparser.ConfigParser(interpolation=None)
-    c.optionxform = str # preserve case
+    c.optionxform = str  # preserve case
     # No file? No config - don't crash.
     if Path(filename).exists():
         c.read(filename)


### PR DESCRIPTION
`experiment_name` keyword renamed to `apparatus_name` in labconfig. Existing config files with the old name will be permitted and:
  - Value of `experiment_name` mapped to `apparatus_name`.
  - [`FutureWarning`](https://docs.python.org/3/library/exceptions.html#FutureWarning) issued.
  - Exception raised if both `experiment_name` and `apparatus_name` exist in labconfig.