### PR TITLE
Minimal working connection table and example experiment script

### DIFF
--- a/labscript_profile/default_profile/labconfig/example.ini
+++ b/labscript_profile/default_profile/labconfig/example.ini
@@ -10,8 +10,8 @@ app_saved_configs = %(labscript_suite)s\app_saved_configs\%(apparatus_name)s
 user_devices = user_devices
 
 [paths]
-connection_table_h5 = %(experiment_shot_storage)s\connectiontable.h5
-connection_table_py = %(labscriptlib)s\connectiontable.py
+connection_table_h5 = %(experiment_shot_storage)s\connection_table.h5
+connection_table_py = %(labscriptlib)s\connection_table.py
 
 [servers]
 zlock = localhost

--- a/labscript_profile/default_profile/userlib/labscriptlib/example_apparatus/connection_table.py
+++ b/labscript_profile/default_profile/userlib/labscriptlib/example_apparatus/connection_table.py
@@ -17,9 +17,11 @@ DigitalOut(
     name='digital_out', parent_device=intermediate_device, connection='port0/line0'
 )
 
-# Begin issuing labscript primitives
-# start() elicits the commencement of the shot
-start()
 
-# Stop the experiment shot with stop()
-stop(1.0)
+if __name__ == '__main__':
+    # Begin issuing labscript primitives
+    # start() elicits the commencement of the shot
+    start()
+
+    # Stop the experiment shot with stop()
+    stop(1.0)

--- a/labscript_profile/default_profile/userlib/labscriptlib/example_apparatus/connection_table.py
+++ b/labscript_profile/default_profile/userlib/labscriptlib/example_apparatus/connection_table.py
@@ -1,0 +1,20 @@
+from labscript import start, stop, add_time_marker, DigitalOut
+from labscript_devices.DummyPseudoclock.labscript_devices import DummyPseudoclock
+from labscript_devices.DummyIntermediateDevice import DummyIntermediateDevice
+
+# Use a virtual, or 'dummy', device for the psuedoclock
+DummyPseudoclock(name='pseudoclock')
+
+# An output of this DummyPseudoclock is its 'clockline' attribute, which we use
+# to trigger children devices
+DummyIntermediateDevice(name='intermediate_device', parent_device=pseudoclock.clockline)
+
+# Create a DigitalOut child of the DummyIntermediateDevice
+DigitalOut(name='digital_out', parent_device=intermediate_device, connection='do0')
+
+# Begin issuing labscript primitives
+# start() elicits the commencement of the shot
+start()
+
+# Stop the experiment shot with stop()
+stop(1.0)

--- a/labscript_profile/default_profile/userlib/labscriptlib/example_apparatus/connection_table.py
+++ b/labscript_profile/default_profile/userlib/labscriptlib/example_apparatus/connection_table.py
@@ -1,4 +1,4 @@
-from labscript import start, stop, add_time_marker, DigitalOut
+from labscript import start, stop, add_time_marker, AnalogOut, DigitalOut
 from labscript_devices.DummyPseudoclock.labscript_devices import DummyPseudoclock
 from labscript_devices.DummyIntermediateDevice import DummyIntermediateDevice
 
@@ -9,8 +9,13 @@ DummyPseudoclock(name='pseudoclock')
 # to trigger children devices
 DummyIntermediateDevice(name='intermediate_device', parent_device=pseudoclock.clockline)
 
+# Create an AnalogOut child of the DummyIntermediateDevice
+AnalogOut(name='analog_out', parent_device=intermediate_device, connection='ao0')
+
 # Create a DigitalOut child of the DummyIntermediateDevice
-DigitalOut(name='digital_out', parent_device=intermediate_device, connection='do0')
+DigitalOut(
+    name='digital_out', parent_device=intermediate_device, connection='port0/line0'
+)
 
 # Begin issuing labscript primitives
 # start() elicits the commencement of the shot

--- a/labscript_profile/default_profile/userlib/labscriptlib/example_apparatus/example_experiment.py
+++ b/labscript_profile/default_profile/userlib/labscriptlib/example_apparatus/example_experiment.py
@@ -1,0 +1,40 @@
+from labscript import start, stop, add_time_marker, DigitalOut
+from labscript_devices.DummyPseudoclock.labscript_devices import DummyPseudoclock
+from labscript_devices.DummyIntermediateDevice import DummyIntermediateDevice
+
+# Use a virtual, or 'dummy', device for the psuedoclock
+DummyPseudoclock(name='pseudoclock')
+
+# An output of this DummyPseudoclock is its 'clockline' attribute, which we use
+# to trigger children devices
+DummyIntermediateDevice(name='intermediate_device', parent_device=pseudoclock.clockline)
+
+# Create a DigitalOut child of the DummyIntermediateDevice
+DigitalOut(name='digital_out', parent_device=intermediate_device, connection='do0')
+
+# Begin issuing labscript primitives
+# A timing variable t is used for convenience
+# start() elicits the commencement of the shot
+t = 0
+add_time_marker(t, "Start", verbose=True)
+start()
+
+# Wait for 1 second with all devices in their default state
+t += 1
+
+# Change the state of digital_out, and denote this using a time marker
+add_time_marker(t, "Toggle digital_out (high)", verbose=True)
+digital_out.go_high(t)
+
+# Wait for 0.5 seconds
+t += 0.5
+
+# Change the state of digital_out, and denote this using a time marker
+add_time_marker(t, "Toggle digital_out (low)", verbose=True)
+digital_out.go_low(t)
+
+# Wait for 0.5 seconds
+t += 0.5
+
+# Stop the experiment shot with stop()
+stop(t)

--- a/labscript_profile/default_profile/userlib/labscriptlib/example_apparatus/example_experiment.py
+++ b/labscript_profile/default_profile/userlib/labscriptlib/example_apparatus/example_experiment.py
@@ -1,4 +1,4 @@
-from labscript import start, stop, add_time_marker, DigitalOut
+from labscript import start, stop, add_time_marker, AnalogOut, DigitalOut
 from labscript_devices.DummyPseudoclock.labscript_devices import DummyPseudoclock
 from labscript_devices.DummyIntermediateDevice import DummyIntermediateDevice
 
@@ -9,8 +9,13 @@ DummyPseudoclock(name='pseudoclock')
 # to trigger children devices
 DummyIntermediateDevice(name='intermediate_device', parent_device=pseudoclock.clockline)
 
+# Create an AnalogOut child of the DummyIntermediateDevice
+AnalogOut(name='analog_out', parent_device=intermediate_device, connection='ao0')
+
 # Create a DigitalOut child of the DummyIntermediateDevice
-DigitalOut(name='digital_out', parent_device=intermediate_device, connection='do0')
+DigitalOut(
+    name='digital_out', parent_device=intermediate_device, connection='port0/line0'
+)
 
 # Begin issuing labscript primitives
 # A timing variable t is used for convenience
@@ -28,6 +33,9 @@ digital_out.go_high(t)
 
 # Wait for 0.5 seconds
 t += 0.5
+
+# Ramp analog_out from 0.0 V to 1.0 V over 0.25 s with a 1 kS/s sample rate
+t += analog_out.ramp(t=t, initial=0.0, final=1.0, duration=0.25, samplerate=1e3)
 
 # Change the state of digital_out, and denote this using a time marker
 add_time_marker(t, "Toggle digital_out (low)", verbose=True)


### PR DESCRIPTION
Include working connection table script and experiment script for the `example_apparatus` (see #53), for whole-suite works-out-of-the-box changes. This change see blacs start without raising an exception upon a fresh install (!) with no additional changes, but will require runmanager to load this experiment script automatically.

While not entirely minimal, it demonstrates some basic precepts like child devices and `add_time_marker`. For this to be a little more meaningful, however, `DummyIntermediateDevice` should probably:
  * Display digital out(s) controls on its blacs tab.
  * Have a runviewer parser (instructions are currently not displayed.

I am working on incrementally more complex examples that don't require any physical hardware to run (including `RemoteBLACS` and `IMAQdxCamera` with `mock=True`), that extend these scripts.