### PR TITLE
Example labscript and analysis scripts for IMAQdxCamera and RemoteBLACS

### DIFF
--- a/labscript_profile/default_profile/userlib/analysislib/example_apparatus/example_IMAQdx_remote.py
+++ b/labscript_profile/default_profile/userlib/analysislib/example_apparatus/example_IMAQdx_remote.py
@@ -1,0 +1,46 @@
+import lyse
+from pathlib import Path
+import matplotlib.pyplot as plt
+
+# Is this script being run from within an interactive lyse session?
+if lyse.spinning_top:
+    # If so, use the filepath of the current shot
+    h5_path = lyse.path
+else:
+    # If not, get the filepath of the last shot of the lyse DataFrame
+    df = lyse.data()
+    h5_path = df.filepath.iloc[-1]
+
+# Instantiate a lyse.Run object for this shot
+run = lyse.Run(h5_path)
+
+# Get a dictionary of the global variables used in this shot
+run_globals = run.get_globals()
+
+# Extract the images 'before' and 'after' generated from camera.expose
+before, after = run.get_images('camera', 'comparison', 'before', 'after')
+
+# Compute the difference of the two images, after casting them to signed integers
+# (otherwise negative differences wrap to 2**16 - 1 - diff)
+diff = after.astype('int16') - before.astype('int16')
+
+# Plot the row-wise mean of each image
+plt.plot(before.mean(axis=0), label='before')
+plt.plot(after.mean(axis=0), label='after')
+plt.xlabel('pixel coordinate (column)')
+plt.ylabel('counts')
+
+# Label the plot with a unique string representing the shot
+plt.title(Path(run.h5_path).name)
+
+# Plot adornments
+plt.legend(loc='lower left')
+plt.grid()
+
+# Show the plot
+plt.show()
+
+# Compute a result based on the image processing and save it to the 'results' group of
+# the shot file
+result = diff.std()
+run.save_result('foobar', result)

--- a/labscript_profile/default_profile/userlib/labscriptlib/example_apparatus/connection_table_IMAQdx_remote.py
+++ b/labscript_profile/default_profile/userlib/labscriptlib/example_apparatus/connection_table_IMAQdx_remote.py
@@ -1,0 +1,40 @@
+from labscript import start, stop, add_time_marker, Trigger, RemoteBLACS
+from labscript_devices.DummyPseudoclock.labscript_devices import DummyPseudoclock
+from labscript_devices.DummyIntermediateDevice import DummyIntermediateDevice
+from labscript_devices.IMAQdxCamera.labscript_devices import IMAQdxCamera
+
+# Use a virtual ('dummy') device for the psuedoclock
+DummyPseudoclock(name='pseudoclock')
+
+# An output of this DummyPseudoclock is its 'clockline' attribute, which we use
+# to trigger children devices
+DummyIntermediateDevice(name='intermediate_device', parent_device=pseudoclock.clockline)
+
+# Instantiate a labscript.Trigger instance used to trigger the camera exposure
+# This will be specified as the camera's parent device later
+Trigger(
+    name='camera_trigger', parent_device=intermediate_device, connection='port0/line0'
+)
+
+# On the host specified below, start the RemoteBLACS server by running the following:
+# $ python - m labscript_utils.remote
+RemoteBLACS(name='test_remote', host='localhost')
+
+# We then initiate an IMAQdxCamera using this RemoteBLACS instance
+# using mock=True to bypass any attempts to commmunicate with an
+# actual camera, and generate fake data at the end of the shot
+IMAQdxCamera(
+    name='camera',
+    parent_device=camera_trigger,
+    connection='trigger',
+    serial_number=0xDEADBEEF,
+    worker=test_remote,
+    mock=True,
+)
+
+# Begin issuing labscript primitives
+# start() elicits the commencement of the shot
+start()
+
+# Stop the experiment shot with stop()
+stop(1.0)

--- a/labscript_profile/default_profile/userlib/labscriptlib/example_apparatus/example_IMAQdx_remote.py
+++ b/labscript_profile/default_profile/userlib/labscriptlib/example_apparatus/example_IMAQdx_remote.py
@@ -1,0 +1,51 @@
+from labscript import start, stop, add_time_marker, Trigger, RemoteBLACS
+from labscript_devices.DummyPseudoclock.labscript_devices import DummyPseudoclock
+from labscript_devices.DummyIntermediateDevice import DummyIntermediateDevice
+from labscript_devices.IMAQdxCamera.labscript_devices import IMAQdxCamera
+
+# Use a virtual ('dummy') device for the psuedoclock
+DummyPseudoclock(name='pseudoclock')
+
+# An output of this DummyPseudoclock is its 'clockline' attribute, which we use
+# to trigger children devices
+DummyIntermediateDevice(name='intermediate_device', parent_device=pseudoclock.clockline)
+
+# Instantiate a labscript.Trigger instance used to trigger the camera exposure
+# This will be specified as the camera's parent device later
+Trigger(
+    name='camera_trigger', parent_device=intermediate_device, connection='port0/line0'
+)
+
+# On the host specified below, start the RemoteBLACS server by running the following:
+# $ python - m labscript_utils.remote
+RemoteBLACS(name='test_remote', host='localhost')
+
+# We then initiate an IMAQdxCamera using this RemoteBLACS instance
+# using mock=True to bypass any attempts to commmunicate with an
+# actual camera, and generate fake data at the end of the shot
+IMAQdxCamera(
+    name='camera',
+    parent_device=camera_trigger,
+    connection='trigger',
+    serial_number=0xDEADBEEF,
+    worker=test_remote,
+    mock=True,
+)
+
+# Begin issuing labscript primitives
+# A timing variable t is used for convenience
+# start() elicits the commencement of the shot
+t = 0
+add_time_marker(t, "Start", verbose=True)
+start()
+
+t += 1
+add_time_marker(t, "Exposure: 'before' image", verbose=True)
+camera.expose(t, name='comparison', frametype='before', trigger_duration=0.2)
+
+t += 0.5
+add_time_marker(t, "Exposure: 'after' image", verbose=True)
+camera.expose(t, name='comparison', frametype='after', trigger_duration=0.2)
+
+t += 0.5
+stop(t)


### PR DESCRIPTION
This example builds upon [testing/test.py](https://github.com/labscript-suite/labscript-devices/blob/master/labscript_devices/IMAQdxCamera/testing/test.py) in [`labscript_devices.IMAQdxCamera`](https://github.com/labscript-suite/labscript-devices/tree/master/labscript_devices/IMAQdxCamera), and illustrates basic usage of the `IMAQdxCamera` labscript device and `RemoteBLACS`. Included are a connection table and labscript experiment script (in userlib/labscriptlib/example_apparatus), and a lyse analysis script (in userlib/analysislib/example_apparatus).

Usage of the following methods of `lyse.Run` are demonstrated: `get_globals()`, `get_images()`, `save_result()`, as well as `lyse.spinning_top`, `lyse.path`, and `lyse.data()`.

## runmanager settings

The labscript experiment script example_IMAQdx_remote.py is loaded into runmanager:

![image](https://user-images.githubusercontent.com/5637107/84616352-1894da00-af0f-11ea-8ba3-c604b7bf7d9d.png)

## blacs display
The IMAQdxCamera in `mock` mode displays the synthetic data after each shot:

![image](https://user-images.githubusercontent.com/5637107/84616438-5560d100-af0f-11ea-9276-c17bfc516630.png)

## `RemoteBLACS` server
The `RemoteBLACS` server (started using `python -m labscript_utils.remote`) shown in a separate terminal:

![image](https://user-images.githubusercontent.com/5637107/84616534-99ec6c80-af0f-11ea-8afa-2ef4816ebc91.png)

## lyse singleshot routines dialog
The single-shot analysis routine example_IMAQdx_remote.py is loaded into lyse:

![image](https://user-images.githubusercontent.com/5637107/84616273-e4211e00-af0e-11ea-8595-d5d438dda042.png)

## Example analysis output 

A 1D plot generated from lineouts of the synthetic image data is displayed:
![image](https://user-images.githubusercontent.com/5637107/84616232-c489f580-af0e-11ea-91d3-ef0b8c741fa7.png)
 
The plot updates automatically when new shots are added to the lyse analysis queue by blacs.