### PR TITLE
Add timeouts section to example.ini

### DIFF
--- a/labscript_profile/default_profile/labconfig/example.ini
+++ b/labscript_profile/default_profile/labconfig/example.ini
@@ -25,6 +25,9 @@ runmanager = 42523
 zlock = 7339
 zprocess_remote = 7341
 
+[timeouts]
+communication_timeout = 60
+
 [programs]
 text_editor = %%PROGRAMFILES%%\Sublime Text 3\sublime_text.exe
 text_editor_arguments = {file}


### PR DESCRIPTION
After https://github.com/labscript-suite/runmanager/pull/96, `runmanager.remote` now supports a `communication_timeout` option in the new `[timeouts]` section of the labconfig. This PR adds that section/option to the example labconfig.