### PR TITLE
Added [labscript] section to example.ini.

### DIFF
--- a/labscript_profile/default_profile/labconfig/example.ini
+++ b/labscript_profile/default_profile/labconfig/example.ini
@@ -31,6 +31,9 @@ text_editor_arguments = {file}
 hdf5_viewer = %%LOCALAPPDATA%%\HDF_Group\HDFView\3.1.0\hdfview.bat
 hdf5_viewer_arguments = {file}
 
+[labscript]
+save_hg_info = True
+save_git_info = False
 
 [BLACS/plugins]
 connection_table = True


### PR DESCRIPTION
This PR adds a `[labscript]` section to the example labconfig with the `save_hg_info` and `save_git_info` options. These are used with https://github.com/labscript-suite/labscript/pull/72, so they should be merged or rejected together.