### PR TITLE
Bugfix for older h5 files

### DIFF
--- a/labscript_utils/connections.py
+++ b/labscript_utils/connections.py
@@ -253,7 +253,7 @@ class Connection(object):
                 return labscript_utils.properties.deserialise(value)
             else:
                 # Backward compatibility with older hdf5 files:
-                return ast.literal_eval(value)
+                return ast.literal_eval(_ensure_str(value))
         return _ensure_str(value)
 
     def _populate_relatives(self, table):


### PR DESCRIPTION

Seems like an `_ensure_str` call was missed in the backwards compatibility with old h5 files when loading the connection table. `ast.literal_eval()` was unable to evaluate `b'None'` prior to this fix.