### PR TITLE
Bugfixes for the mistakes in #70

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ defaults:
 
 env:
   PACKAGE_NAME: labscript-utils
+  SCM_LOCAL_SCHEME: no-local-version
   ANACONDA_USER: labscript-suite
 
   # Configuration for a package with compiled extensions:

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,7 @@ install_requires =
   importlib_metadata>=1.0
   h5py>=2.9
   numpy>=1.15
+  packaging>=20.4
   pyqtgraph>=0.11.0rc0
   qtutils>=2.2.3
   scipy

--- a/setup.py
+++ b/setup.py
@@ -16,4 +16,9 @@ class develop_command(develop):
                 self.copy_file('labscript-suite.pth', path)
 
 
-setup(cmdclass={'develop': develop_command})
+VERSION_SCHEME = {
+    "version_scheme": os.getenv("SCM_VERSION_SCHEME", "release-branch-semver"),
+    "local_scheme": os.getenv("SCM_LOCAL_SCHEME", "node-and-date"),
+}
+
+setup(use_scm_version=VERSION_SCHEME, cmdclass={'develop': develop_command})


### PR DESCRIPTION

labscript-suite/labscript-suite#53 erroenously removed the env var that removed the local version (required for uploading to test PyPI).

Contrary to my statements in #62, the packaging library does not seem to be a dependency of setuptools. Instead they have vendored it as an internal submodule. Rather than rely on that, packaging is now a dependency of labscript-utils directly.