### PR TITLE
Removes setuptools_scm configuration from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,3 @@
 [build-system]
 requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=4.1.0"]
 build-backend = "setuptools.build_meta"
-
-[tool.setuptools_scm]
-version_scheme = "release-branch-semver"
-local_scheme = "node-and-date"


### PR DESCRIPTION

#70 introduced changes to the pyproject.toml file. These settings supersede those in setup.py, and cannot depend on environment variables. However, we need to suppress the local version when building for test PyPI (but not when running locally).

As such, I see no way to utilise pyproject.toml for these settings, and am reverting to using the configuration specified in setup.py (restored in #71)