### PR TITLE
Fixed bug in unitconversions._All._import_all()

### DIFF
--- a/labscript_utils/unitconversions/__init__.py
+++ b/labscript_utils/unitconversions/__init__.py
@@ -26,7 +26,6 @@ class _All(object):
 
     def __getitem__(self, ix):
         if self.__all__ is None:
-            self.__all__ = []
             self._import_all()
         return self.__all__[ix]
 
@@ -34,6 +33,8 @@ class _All(object):
         """imports all unit conversion classes in module within this subpackage into
         this module's globals. This is used only for backward compatibility with unit
         conversion classes that were not specified with a fully qualified name"""
+        if self.__all__ is None:
+            self.__all__ = []
         for filename in os.listdir(os.path.split(__file__)[0]):
             if filename.endswith('.py') and filename != '__init__.py':
                 module = filename[:-3]


### PR DESCRIPTION
Previously in `unitconversions._All._import_all()` , `self.__all__` wasn't always changed from `None` to an empty list before appending things to it. In particular that wouldn't happen when explicitly calling `._All._import_all()` instead of using its `__getitem__()` method first. That would raise ` AttributeError: 'NoneType' object has no attribute 'append'`. This PR edits `._All._import_all()` to ensure that it is always set to an empty list before appending things to it.

During startup, [the blacs code here](https://github.com/labscript-suite/blacs/blob/348bbeb349d2cf758dcdf668c26efc6321a00e00/blacs/output_classes.py#L54-L60) would suppress that error. It assumes that the `AttributeError` was raised because the desired unit conversion class didn't exist in the module, which would cause a somewhat misleading error message to be logged. Took me a while with a debugger to figure out that python can import the module, it just fails to import because `_All._import_all()` errors out first.