### PR TITLE
Work around infinite recursion in ToolPalette.resizeEvent()

### DIFF
--- a/labscript_utils/qtwidgets/toolpalette.py
+++ b/labscript_utils/qtwidgets/toolpalette.py
@@ -405,15 +405,6 @@ class ToolPalette(QScrollArea):
 
     def resizeEvent(self, event):
         # overwrite the resize event!
-        # print '--------- %s'%self._name
-        # print self._widget_list[0].size()
-        # print self._widget_list[0].sizeHint()
-        # print self._widget_list[0].minimumSizeHint()
-        # print self._layout.rowMinimumHeight(0)
-        # print self.size()
-        # print self.minimumSize()
-        # print self.sizeHint()
-        # print self.minimumSizeHint()
         # This method can end up undergoing infinite recursion for some window
         # layouts, see
         # https://github.com/labscript-suite/labscript-utils/issues/27. It seems

--- a/labscript_utils/qtwidgets/toolpalette.py
+++ b/labscript_utils/qtwidgets/toolpalette.py
@@ -19,6 +19,8 @@ from qtutils.qt.QtWidgets import *
 EXPAND_ICON = ':/qtutils/fugue/toggle-small-expand'
 CONTRACT_ICON = ':/qtutils/fugue/toggle-small'
 
+_ENABLE_LAYOUT_EVENT_TYPE = QEvent.User
+
 class ToolPaletteGroup(QVBoxLayout):
     
     def __init__(self,*args,**kwargs):
@@ -265,6 +267,10 @@ class ToolPalette(QScrollArea):
         self._column_count = 0
         self._row_count = 0
         
+        # Variable for controlling whether or not self._layout_widgets() is
+        # called in self.resizeEvent().
+        self._layout_widgets_during_resizeEvent = True
+        
     def addWidget(self,widget,force_relayout=True):
         # Append to end of tool pallete
         #widget.clicked.connect(embed)
@@ -385,6 +391,18 @@ class ToolPalette(QScrollArea):
         height = self.minimumSize().height()
         return QSize(width, height)
 
+    def event(self, event):
+        # Handle the custom event for reenabling the call to
+        # self._layout_widgets() during self.resizeEvent().
+        if (event.type() == _ENABLE_LAYOUT_EVENT_TYPE):
+            self._layout_widgets_during_resizeEvent = True
+            # Return True so that this event isn't sent along to other event
+            # handlers as well.
+            return True
+
+        # Handle all other events in the usual way.
+        return super().event(event)
+
     def resizeEvent(self, event):
         # overwrite the resize event!
         # print '--------- %s'%self._name
@@ -396,13 +414,39 @@ class ToolPalette(QScrollArea):
         # print self.minimumSize()
         # print self.sizeHint()
         # print self.minimumSizeHint()
-        #pass resize event on to qwidget
-        # call layout()
-        QWidget.resizeEvent(self, event)
-        size = event.size()
-        if size.width() == self.size().width() and size.height() == self.size().height():
-            # print 'relaying out widgets'
-            self._layout_widgets()
+        # This method can end up undergoing infinite recursion for some window
+        # layouts, see
+        # https://github.com/labscript-suite/labscript-utils/issues/27. It seems
+        # that sometimes self._layout_widgets() increases the number of columns,
+        # which then triggers a resizeEvent, which then calls
+        # self._layout_widgets() which then decreases the number of columns to
+        # its previous value, which triggers a resizeEvent, and so on. That loop
+        # may occur e.g. if increasing/decreasing the number of columns
+        # add/removes a scrollbar, which then changes the number of widgets that
+        # can fit in a row. Keeping track of the recursion depth isn't trivial
+        # because _layout_widgets() doesn't directly call itself; it just causes
+        # more resizing events to be added to the event queue. To work around
+        # that, this method will mark that future calls to this method shouldn't
+        # call _layout_widgets() but will also add an event to the event queue
+        # to reenable calling _layout_widgets() again once all of the resize
+        # events caused by this call to it have been processed.
+        
+        try:
+            #pass resize event on to qwidget
+            QWidget.resizeEvent(self, event)
+            size = event.size()
+            if size.width() == self.size().width() and size.height() == self.size().height():
+                if self._layout_widgets_during_resizeEvent:
+                    # Avoid calling this again until all the resize events that
+                    # will be put in the queue by self._layout_widgets() have
+                    # run.
+                    self._layout_widgets_during_resizeEvent = False
+                    self._layout_widgets()
+        finally:
+            # Add event to end of the event queue to allow _layout_widgets() in
+            # future calls. This event shouldn't be handled until the resize
+            # events generated during _layout_widgets() have run.
+            QCoreApplication.instance().postEvent(self, QEvent(_ENABLE_LAYOUT_EVENT_TYPE))
 
 
 # A simple test!


### PR DESCRIPTION
This PR resolves #27. It takes the approach suggested there of effectively turning off the resize event signal while handling a resize event so as to avoid infinite recursion.

The implementation is a bit different than might be expected. The recursion happens because `ToolPalette.resizeEvent()` calls `ToolPalette._layout_widgets()`, which can cause more resize events to be added to the Qt event queue, which in turn causes more calls to `resizeEvent()`. I'm not aware of any good way to prevent those events from being generated (though I'm not a Qt expert so that could very well be possible). Also, the calls to `resizeEvent()` execute to completion before it is called again by the event loop. That means that temporarily changing things during the method's execution (such as incrementing/decrementing a recursion level counter or temporarily redefining `self.resizeEvent()` to avoid recursion) don't work.

The approach taken here is that the first call to `resizeEvent()` sets `self._layout_widgets_during_resizeEvent` to `False` to signal that the upcoming calls of `resizeEvent()` shouldn't call `_layout_widgets()`. It then calls `_layout_widgets()` which may cause resize events to be added to the events queue. Finally before returning, `resizeEvent()` puts a custom event on the end of the event queue which will cause the `ToolPalette` to set `self._layout_widgets_during_resizeEvent` back to `True` again. That ensures that eventually resize events will cause `_layout_widgets()` again, which is required for resizing to work well. That custom event isn't handled until all of the resize events generated before it in `_layout_widgets()` run though, which circumvents the infinite recursion.

I've tested this PR with two problematic blacs settings files (including the one mentioned [here](https://github.com/labscript-suite/labscript-utils/issues/27#issuecomment-732542971)) and both crashed without the changes here but started up fine with the changes. I've also seen that once blacs is started, the `ToolPalette`s still seem to resize just fine; the number of widgets per row still increases/decreases as needed when the tab is expanded/contracted.

