### PR TITLE
Make setup_logging() more Jupyter-friendly.

### DIFF
--- a/labscript_utils/setup_logging.py
+++ b/labscript_utils/setup_logging.py
@@ -11,6 +11,7 @@
 #                                                                   #
 #####################################################################
 import sys, os
+from io import UnsupportedOperation
 import logging, logging.handlers
 from labscript_utils.ls_zprocess import Handler, ensure_connected_to_zlog
 
@@ -52,21 +53,26 @@ def setup_logging(program_name, log_level=logging.DEBUG, terminal_level=logging.
     handler.setFormatter(formatter)
     handler.setLevel(log_level)
     logger.addHandler(handler)
-    if sys.stdout is not None and sys.stdout.fileno() >= 0:
-        stdout_handler = logging.StreamHandler(sys.stdout)
-        stdout_handler.setFormatter(formatter)
-        stdout_handler.setLevel(terminal_level)
-        logger.addHandler(stdout_handler)
-        if sys.stderr is not None and sys.stderr.fileno() >= 0:
-            # Send warnings and greater to stderr instead of stdout:
-            stdout_handler.addFilter(LessThanFilter(logging.WARNING))
-            sterr_handler = logging.StreamHandler(sys.stderr)
-            sterr_handler.setFormatter(formatter)
-            sterr_handler.setLevel(logging.WARNING)
-            logger.addHandler(sterr_handler)
-    else:
-        # Prevent bug on windows where writing to stdout without a command
-        # window causes a crash:
-        sys.stdout = sys.stderr = open(os.devnull, 'w')
+    try:
+        if sys.stdout is not None and sys.stdout.fileno() >= 0:
+            stdout_handler = logging.StreamHandler(sys.stdout)
+            stdout_handler.setFormatter(formatter)
+            stdout_handler.setLevel(terminal_level)
+            logger.addHandler(stdout_handler)
+            if sys.stderr is not None and sys.stderr.fileno() >= 0:
+                # Send warnings and greater to stderr instead of stdout:
+                stdout_handler.addFilter(LessThanFilter(logging.WARNING))
+                sterr_handler = logging.StreamHandler(sys.stderr)
+                sterr_handler.setFormatter(formatter)
+                sterr_handler.setLevel(logging.WARNING)
+                logger.addHandler(sterr_handler)
+        else:
+            # Prevent bug on windows where writing to stdout without a command
+            # window causes a crash:
+            sys.stdout = sys.stderr = open(os.devnull, 'w')
+    except UnsupportedOperation:
+        # Special handling for Jupyter notebook kernels where sys.stdout.fileno is not
+        # callable.
+        pass
     logger.setLevel(logging.DEBUG)
     return logger

--- a/labscript_utils/setup_logging.py
+++ b/labscript_utils/setup_logging.py
@@ -13,6 +13,7 @@
 import sys, os
 from io import UnsupportedOperation
 import logging, logging.handlers
+import warnings
 from labscript_utils.ls_zprocess import Handler, ensure_connected_to_zlog
 
 
@@ -73,6 +74,8 @@ def setup_logging(program_name, log_level=logging.DEBUG, terminal_level=logging.
     except UnsupportedOperation:
         # Special handling for Jupyter notebook kernels where sys.stdout.fileno is not
         # callable.
-        pass
+        warnings.warn(
+            "Logging to stdout and stderr is disabled. See the log files for log messages."
+        )
     logger.setLevel(logging.DEBUG)
     return logger

--- a/labscript_utils/setup_logging.py
+++ b/labscript_utils/setup_logging.py
@@ -57,7 +57,7 @@ def setup_logging(program_name, log_level=logging.DEBUG, terminal_level=logging.
     try:
         # Check that sys.stdout.fileno is callable, which is needed below. It is NOT
         # callable in Jupyter notebooks.
-        sys.stdout.fileno()
+        stdout_fileno = sys.stdout.fileno()
     except UnsupportedOperation:
         # In this case the code is likely being run from a Jupyter notebook, warn the
         # user that log messages won't be printed to stdout or stderr.
@@ -65,7 +65,7 @@ def setup_logging(program_name, log_level=logging.DEBUG, terminal_level=logging.
             "Logging to stdout and stderr is disabled. See the log files for log messages."
         )
     else:
-        if sys.stdout is not None and sys.stdout.fileno() >= 0:
+        if sys.stdout is not None and stdout_fileno >= 0:
             stdout_handler = logging.StreamHandler(sys.stdout)
             stdout_handler.setFormatter(formatter)
             stdout_handler.setLevel(terminal_level)


### PR DESCRIPTION
It can be helpful to import code from labscript programs into Jupyter notebooks, particularly for development and debugging purposes. For example, I'm currently using the `runviewer.__main__.Shot` class to generate some plots. However, with the current version of `labscript_utils`, running `from runviewer.__main__ import Shot` from a Jupyter notebook fails, so the code cannot be imported. In the past I've seen this issue when importing some other labscript components as well.

The import fails because importing `runviewer.__main__` calls `labscript_utils.setup_logging.setup_logging()`, which in turn raises an `UnsupportedOperation` error (example traceback below). The issue is that Jupyter kernels do some special things with stdout and stderr, which means that `sys.stdout.fileno` and `sys.stderr.fileno` exist but aren't callable in a Jupyter notebook. This PR changes `setup_logging()` to catch the `UnsupportedOperation` error thrown when it is run (possibly indirectly) from a Jupyter notebook. When the error is caught, logging output isn't directed to stdout or stderr, but is still sent to the log files. Note that setting `sys.stdout = sys.stderr = open(os.devnull, 'w')` isn't a good idea in this case because it prevents `print()` statements (and likely other output as well) from working in the Jupyter notebook.

This might be too niche of a problem to be worth merging. That said, it would be nice to be able to work on labscript code in a jupyter notebook and I have run into this issue multiple times.


Example traceback:
```python
---------------------------------------------------------------------------
UnsupportedOperation                      Traceback (most recent call last)
<ipython-input-1-a4e555dfbf6f> in <module>
----> 1 from runviewer.__main__ import Shot as RVShot

c:\users\username\software\labscript\runviewer\runviewer\__main__.py in <module>
     37 splash.update_text('importing labscript suite modules')
     38 from labscript_utils.setup_logging import setup_logging
---> 39 logger = setup_logging('runviewer')
     40 labscript_utils.excepthook.set_logger(logger)
     41 

c:\users\username\software\labscript\labscript-utils\labscript_utils\setup_logging.py in setup_logging(program_name, log_level, terminal_level, maxBytes, backupCount)
     53     handler.setLevel(log_level)
     54     logger.addHandler(handler)
---> 55     if sys.stdout is not None and sys.stdout.fileno() >= 0:
     56         stdout_handler = logging.StreamHandler(sys.stdout)
     57         stdout_handler.setFormatter(formatter)

UnsupportedOperation: fileno
```