### PR TITLE
Fix bug on Python3.6

### DIFF
--- a/labscript_profile/__init__.py
+++ b/labscript_profile/__init__.py
@@ -49,7 +49,10 @@ def add_userlib_and_pythonlib():
     time the interpreter starts up"""
     labconfig = default_labconfig_path()
     if labconfig is not None and labconfig.exists():
-        config = ConfigParser(defaults={'labscript_suite': LABSCRIPT_SUITE_PROFILE})
+        # str() below is for py36 compat, where ConfigParser can't deal with Path objs
+        config = ConfigParser(
+            defaults={'labscript_suite': str(LABSCRIPT_SUITE_PROFILE)}
+        )
         config.read(labconfig)
         for option in ['userlib', 'pythonlib']:
             try:

--- a/labscript_utils/labconfig.py
+++ b/labscript_utils/labconfig.py
@@ -43,7 +43,8 @@ class LabConfig(configparser.ConfigParser):
             required_params = {}
         if defaults is None:
             defaults = {}
-        defaults['labscript_suite'] = LABSCRIPT_SUITE_PROFILE
+        # str() below is for py36 compat, where ConfigParser can't deal with Path objs
+        defaults['labscript_suite'] = str(LABSCRIPT_SUITE_PROFILE)
         if isinstance(config_path, list):
             self.config_path = config_path[0]
         else:


### PR DESCRIPTION
 where Path object not able to be treated as a string in ConfigParser.

This leads to errors when trying to read keys from labconfig.