### PR TITLE
Prevent starting a zlock server when importing `h5_lock` on RTD.

### DIFF
--- a/labscript_utils/h5_lock.py
+++ b/labscript_utils/h5_lock.py
@@ -89,6 +89,9 @@ def hack_locks_onto_h5py():
     # Monkeypatch h5py so all files are locked:
     h5py.File = File
 
-
-connect_to_zlock_server()
-hack_locks_onto_h5py()
+if os.environ.get('READTHEDOCS'):
+    # prevent starting a zlock server on RTD, which always fails
+    pass
+else:
+    connect_to_zlock_server()
+    hack_locks_onto_h5py()


### PR DESCRIPTION
Current build fails certain submodules due to h5_lock shenanigans, same as experienced in other suite components described in labscript-suite/labscript-suite#65.

Unlike other components, can't just mock, so adding an environment variable check to prevent running `connect_to_zlock_server` when importing `labscript_utils.h5_lock`.