### PR TITLE
Replace distutils

### DIFF
--- a/labscript_utils/ls_zprocess.py
+++ b/labscript_utils/ls_zprocess.py
@@ -13,7 +13,7 @@
 import sys
 import os
 from socket import gethostbyname
-from distutils.version import LooseVersion
+from packaging.version import Version
 import zmq
 
 import zprocess
@@ -337,7 +337,7 @@ def connect_to_zlock_server():
     global _zlock_server_supports_readwrite
     if hasattr(client, 'get_protocol_version'):
         version = client.get_protocol_version()
-        if LooseVersion(version) >= LooseVersion('1.1.0'):
+        if Version(version) >= Version('1.1.0'):
             _zlock_server_supports_readwrite = True
 
     # The user can call these functions to change the timeouts later if they

--- a/labscript_utils/modulewatcher.py
+++ b/labscript_utils/modulewatcher.py
@@ -16,16 +16,16 @@ import time
 import os
 import imp
 import site
-import distutils.sysconfig
+import sysconfig
 
 
 # Directories in which the standard library and installed packages may be located.
 # Modules in these locations will be whitelisted:
 PKGDIRS = [
-    distutils.sysconfig.get_python_lib(plat_specific=True, standard_lib=True),
-    distutils.sysconfig.get_python_lib(plat_specific=True, standard_lib=False),
-    distutils.sysconfig.get_python_lib(plat_specific=False, standard_lib=True),
-    distutils.sysconfig.get_python_lib(plat_specific=False, standard_lib=False),
+    sysconfig.get_path('platstdlib'),
+    sysconfig.get_path('platlib'),
+    sysconfig.get_path('stdlib'),
+    sysconfig.get_path('purelib'),
     site.getusersitepackages(),
 ]
 PKGDIRS += site.getsitepackages()

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import os
 from setuptools import setup
 from setuptools.command.develop import develop
-from distutils import log
+import logging
 
 
 class develop_command(develop):
@@ -11,7 +11,7 @@ class develop_command(develop):
         path = os.path.join(self.install_dir, 'labscript-suite.pth')
         super().run()
         if not self.uninstall:
-            log.info(f'Copying labscript-suite.pth to {path}')
+            logging.info(f'Copying labscript-suite.pth to {path}')
             if not self.dry_run:
                 self.copy_file('labscript-suite.pth', path)
 


### PR DESCRIPTION
Given distutils is being deprecated, going ahead and removing remaining incidental calls with the preferred alternatives.

Ideally, this does not change any actual functionality. I did already confirm that the modulewatcher paths are identical. Other changes are fairly minor and should not be breaking.

Fixes #85 