### PR TITLE
Include labscript-suite.pth in editable wheels

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,24 @@ from setuptools import setup
 from setuptools.command.develop import develop
 import logging
 
+# Setupstools >=64
+try:
+    from setuptools.command.editable_wheel import editable_wheel
+except ImportError:
+    editable_wheel_command = None
+else:
+    from wheel.wheelfile import WheelFile
 
+    class editable_wheel_command(editable_wheel):
+        """Custom editable_wheel command which installs the .pth file to the
+        wheel file for editable installs."""
+        def _create_wheel_file(self, bdist_wheel):
+            wheel_path = super()._create_wheel_file(bdist_wheel)
+            with WheelFile(wheel_path, 'a') as wheel:
+                wheel.write("labscript-suite.pth")
+
+
+# Setuptools <= 63:
 class develop_command(develop):
     """Custom develop command which installs the .pth file to site-packages for editable
     installs."""
@@ -21,4 +38,10 @@ VERSION_SCHEME = {
     "local_scheme": os.getenv("SCM_LOCAL_SCHEME", "node-and-date"),
 }
 
-setup(use_scm_version=VERSION_SCHEME, cmdclass={'develop': develop_command})
+setup(
+    use_scm_version=VERSION_SCHEME,
+    cmdclass={
+        'develop': develop_command,
+        'editable_wheel': editable_wheel_command,
+    },
+)

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ else:
             wheel_path = super()._create_wheel_file(bdist_wheel)
             with WheelFile(wheel_path, 'a') as wheel:
                 wheel.write("labscript-suite.pth")
+            return wheel_path
 
 
 # Setuptools <= 63:


### PR DESCRIPTION
This ensures user directories are added to the Python import path in editable installs that are performed via the new PEP660 mechanism used by default in newer versions of pip and setuptools.

The existing custom `develop` command is retained for compatibility with older setuptools and pip, which use `python setup.py develop` to create editable installs. It can be removed once it is safe to assume PEP660 functionality is available and default on all supported pip and setuptools versions sometime in the future.

Fixes #90 