### PR TITLE
Moving `get_shot_globals` function from runmanager to labscript_utils.

### DIFF
--- a/labscript_utils/shot_utils.py
+++ b/labscript_utils/shot_utils.py
@@ -1,0 +1,37 @@
+#####################################################################
+#                                                                   #
+# __init__.py                                                       #
+#                                                                   #
+# Copyright 2013, Monash University                                 #
+#                                                                   #
+# This file is part of the labscript suite (see                     #
+# http://labscriptsuite.org) and is licensed under the Simplified   #
+# BSD License. See the license.txt file in the root of the project  #
+# for the full license.                                             #
+#                                                                   #
+#####################################################################
+
+import h5py
+import numpy as np
+
+def get_shot_globals(filepath):
+    """Returns the evaluated globals for a shot, for use by labscript or lyse.
+    Simple dictionary access as in dict(h5py.File(filepath).attrs) would be fine
+    except we want to apply some hacks, so it's best to do that in one place."""
+    params = {}
+    with h5py.File(filepath, 'r') as f:
+        for name, value in f['globals'].attrs.items():
+            # Convert numpy bools to normal bools:
+            if isinstance(value, np.bool_):
+                value = bool(value)
+            # Convert null HDF references to None:
+            if isinstance(value, h5py.Reference) and not value:
+                value = None
+            # Convert numpy strings to Python ones.
+            # DEPRECATED, for backward compat with old files.
+            if isinstance(value, np.str_):
+                value = str(value)
+            if isinstance(value, bytes):
+                value = value.decode()
+            params[name] = value
+    return params


### PR DESCRIPTION
This will allow us to break lyse's dependency on runmanager., as described in labscript-suite/runmanager#98.

After this is merged, will need to 

- [ ] tag a new minor release that other modules can depend on
- [ ] PR for runmanager to point to new location
- [ ] PR for labscript-devices to point to new location
- [ ] PR for lyse to point to the new location.