### PR TITLE
Set some Qt settings to play nicer on High DPI displays

### DIFF
--- a/labscript_utils/splash.py
+++ b/labscript_utils/splash.py
@@ -29,6 +29,15 @@ except ImportError as e:
 Qt = QtCore.Qt
 
 
+# Set auto high-DPI scaling - this ensures pixel metrics are scaled
+# appropriately so that we don't get a weird mix of large fonts and small
+# everything else on High DPI displays:
+QtWidgets.QApplication.setAttribute(Qt.AA_EnableHighDpiScaling, True)
+# Use high res pixmaps if available, instead of rendering at low resolution and
+# upscaling:
+QtWidgets.QApplication.setAttribute(Qt.AA_UseHighDpiPixmaps, True)
+
+
 class Splash(QtWidgets.QFrame):
     w = 250
     h = 230


### PR DESCRIPTION
`labscript_utils.splash` is the first place a `QApplication` gets created for all of our apps. So setting these settings there applies them to all our applications, although they are also needed for the splash screen itself to be scaled better on High DPI displays.

`AA_EnableHighDpiScaling` scales all pixel metrics to the device pixel ratio - so this means curved edges and padding and whatnot get scaled up, as well as the size of some pixmaps.

`AA_UseHighDpiPixmaps` means to use high DPI pixmaps for icons etc, directly, rather than rendering them at the lower resolution and then scaling them up (not sure why anyone would want the latter behaviour). Strangely, high resolution pixmaps *are* used when `AA_EnableHighDpiScaling` is *off*. It's only when it is turned on that they get downscaled and then upscaled again and end up blocky.

Before:

![image](https://user-images.githubusercontent.com/1044087/230717031-f0da0ecb-d76a-416c-a283-876f5d2b9aba.png)

After:

![image](https://user-images.githubusercontent.com/1044087/230717003-8d7641cc-10c6-4ead-8aef-88eca8985988.png)

There are some other places where is it maybe more obvious like this tiny icon in BLACS:

![image](https://user-images.githubusercontent.com/1044087/230717100-fa971642-08bb-40b1-9adb-b1d39eabcec0.png)

Which is full-sized after these changes:

![image](https://user-images.githubusercontent.com/1044087/230717138-2433d802-57c5-4145-9343-11b5c28c40b3.png)

With [higher resolution icons](https://github.com/chrisjbillington/fugue-2x-icons) in qtutils now, things should be pretty good on High DPI displays.