### PR TITLE
Fix issue with dragdroptab - convert float coords to int

### DIFF
--- a/labscript_utils/qtwidgets/dragdroptab.py
+++ b/labscript_utils/qtwidgets/dragdroptab.py
@@ -316,7 +316,9 @@ class TabAnimation(QAbstractAnimation):
                 if dy * (target_pos_y - new_pos_y) < 0:
                     new_pos_y = target_pos_y
 
-                self.limbo_position = QPoint(new_pos_x, new_pos_y)
+                self.limbo_position = QPoint(
+                    int(round(new_pos_x)), int(round(new_pos_y))
+                )
             else:
                 self.limbo.animation_over()
                 self.limbo = None


### PR DESCRIPTION
QPoint no longer auto converts float arguments, resulting in an error

This resolves an issue where dragging a tab outside of the main window results in this exception:
```
Traceback (most recent call last):
  File "/home/bilbo/miniconda3/envs/py311/lib/python3.11/site-packages/labscript_utils/qtwidgets/dragdroptab.py", line 319, in updateCurrentTime
    self.limbo_position = QPoint(new_pos_x, new_pos_y)
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: arguments did not match any overloaded call:
  QPoint(): too many arguments
  QPoint(int, int): argument 1 has unexpected type 'float'
  QPoint(QPoint): argument 1 has unexpected type 'float'

```