### PR TITLE
Fixes an issue where `imp` is no longer a python module

### DIFF
--- a/labscript_utils/device_registry/_device_registry.py
+++ b/labscript_utils/device_registry/_device_registry.py
@@ -6,7 +6,7 @@ import inspect
 from labscript_utils import dedent
 from labscript_utils.labconfig import LabConfig
 
-# deal with removal of _imp from new python
+# deal with removal of imp from python 3.12
 try:
     import _imp as imp
 except ImportError:

--- a/labscript_utils/device_registry/_device_registry.py
+++ b/labscript_utils/device_registry/_device_registry.py
@@ -1,11 +1,16 @@
 import os
 import importlib
-import imp
 import warnings
 import traceback
 import inspect
 from labscript_utils import dedent
 from labscript_utils.labconfig import LabConfig
+
+# deal with removal of _imp from new python
+try:
+    import _imp as imp
+except ImportError:
+    import imp
 
 """This file contains the machinery for registering and looking up what BLACS tab and
 runviewer parser classes belong to a particular labscript device. "labscript device"

--- a/labscript_utils/modulewatcher.py
+++ b/labscript_utils/modulewatcher.py
@@ -17,7 +17,7 @@ import os
 import site
 import sysconfig
 
-# deal with removal of _imp from new python
+# deal with removal of imp from python 3.12
 try:
     import _imp as imp
 except ImportError:

--- a/labscript_utils/modulewatcher.py
+++ b/labscript_utils/modulewatcher.py
@@ -14,9 +14,14 @@ import sys
 import threading
 import time
 import os
-import imp
 import site
 import sysconfig
+
+# deal with removal of _imp from new python
+try:
+    import _imp as imp
+except ImportError:
+    import imp
 
 
 # Directories in which the standard library and installed packages may be located.


### PR DESCRIPTION
Fixes issue [https://github.com/labscript-suite/labscript-utils/issues/100](url)