### PR TITLE
Modify default zmq binding address to use `tcp://*`

### DIFF
--- a/labscript_utils/ls_zprocess.py
+++ b/labscript_utils/ls_zprocess.py
@@ -167,7 +167,7 @@ class ZMQServer(zprocess.ZMQServer):
         port=None,
         dtype='pyobj',
         pull_only=False,
-        bind_address='tcp://0.0.0.0',
+        bind_address='tcp://*',
         timeout_interval=None,
         **kwargs
     ):

--- a/labscript_utils/qtwidgets/outputbox.py
+++ b/labscript_utils/qtwidgets/outputbox.py
@@ -29,5 +29,5 @@ class OutputBox(qtutils.outputbox.OutputBox):
             container=container,
             scrollback_lines=scrollback_lines,
             zmq_context=context,
-            bind_address='tcp://0.0.0.0',
+            bind_address='tcp://*',
         )


### PR DESCRIPTION
Fixes compatibility with zmq>=26