### PR TITLE
Make splash screen widget compatible with PySide6

### DIFF
--- a/labscript_utils/splash.py
+++ b/labscript_utils/splash.py
@@ -87,10 +87,6 @@ class Splash(QtWidgets.QFrame):
         self._paint_pending = False
         return super().paintEvent(event)
 
-    def show(self):
-        QtWidgets.QFrame.show(self)
-        self.update_text(self.text)
-
     def update_text(self, text):
         self.text = text
         self.label.setText(text)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
     "numpy>=1.15",
     "packaging>=20.4",
     "pyqtgraph>=0.11.0rc0",
-    "qtutils>=2.2.3",
+    "qtutils>=4.0",
     "scipy",
     "setuptools_scm>=4.1.0",
     "zprocess>=2.18.0",


### PR DESCRIPTION
Unsure about the status of the other widgets in `labscript-utils`, figure I'll address them when testing the other applications with PySide6. The need to modify the splash screen became apparent when adding PySide6 compatibility for runmanager (https://github.com/labscript-suite/runmanager/pull/118).

This now works with either PyQt5 or PySide6, and is a bit of an improvement regardless - it follows more closely what Qt's build-in spash screen widget does.