### PR TITLE
Example compilation

### DIFF
--- a/labscript_profile/create.py
+++ b/labscript_profile/create.py
@@ -95,7 +95,7 @@ def create_profile():
                         help='Sets the apparatus_name in the labconfig file. Defaults to example_apparatus',
                         )
     parser.add_argument('-c', '--compile',
-                        type=bool,
+                        action='store_true',
                         help='Enables compilation of the default example connection table',
                         default=False)
     

--- a/labscript_profile/create.py
+++ b/labscript_profile/create.py
@@ -91,9 +91,13 @@ def create_profile():
                                      )
 
     parser.add_argument('-n', '--apparatus_name',
-                        type = str,
-                        help = 'Sets the apparatus_name in the labconfig file. Defaults to example_apparatus',
+                        type=str,
+                        help='Sets the apparatus_name in the labconfig file. Defaults to example_apparatus',
                         )
+    parser.add_argument('-c', '--compile',
+                        type=bool,
+                        help='Enables compilation of the default example connection table',
+                        default=False)
     
     args = parser.parse_args()
 
@@ -123,5 +127,6 @@ def create_profile():
             new_path = Path(str(path).replace('example_apparatus', args.apparatus_name))
             path.rename(new_path)
 
-    # compile the initial example connection table
-    compile_connection_table()
+    if args.compile:
+        # compile the initial example connection table
+        compile_connection_table()

--- a/labscript_profile/create.py
+++ b/labscript_profile/create.py
@@ -22,7 +22,14 @@ def make_shared_secret(directory):
     raise RuntimeError("Could not parse output of zprocess.makesecret")
 
 
-def make_labconfig_file(apparatus_name):
+def make_labconfig_file(apparatus_name = None):
+    """Create labconfig file from template
+    
+    Parameters
+    ----------
+    apparatus_name: str, optional
+        Overrides the default apparatus name with the provided one if not None
+    """
 
     source_path = os.path.join(LABSCRIPT_SUITE_PROFILE, 'labconfig', 'example.ini')
     target_path = default_labconfig_path()
@@ -57,6 +64,10 @@ def make_labconfig_file(apparatus_name):
         config.write(f)
 
 def compile_connection_table():
+    """Compile the connection table defined in the labconfig file
+    
+    The output is placed in the location defined by the labconfig file.
+    """
 
     try:
         import runmanager
@@ -86,6 +97,8 @@ def compile_connection_table():
     print(f'\tOutput written to {output_h5_path}')
 
 def create_profile():
+    """Function that defines the labscript-profile-create command
+    """
 
     # capture CMD arguments
     parser = argparse.ArgumentParser(prog='labscript-profile-create',

--- a/labscript_profile/create.py
+++ b/labscript_profile/create.py
@@ -50,6 +50,7 @@ def make_labconfig_file(apparatus_name):
     )
     config.set('security', 'shared_secret', str(shared_secret_entry))
     if apparatus_name is not None:
+        print(f'\tSetting apparatus name to \'{apparatus_name}\'')
         config.set('DEFAULT', 'apparatus_name', apparatus_name)
 
     with open(target_path, 'w') as f:
@@ -82,6 +83,7 @@ def compile_connection_table():
                                        run_file = output_h5_path,
                                        stream_port = None,
                                        done_callback = dummy_callback)
+    print(f'\tOutput written to {output_h5_path}')
 
 def create_profile():
 
@@ -103,6 +105,7 @@ def create_profile():
 
     src = Path(DEFAULT_PROFILE_CONTENTS)
     dest = Path(LABSCRIPT_SUITE_PROFILE)
+    print(f'Creating labscript profile at {LABSCRIPT_SUITE_PROFILE}')
     # Profile directory may exist already, but we will error if it contains any of the
     # sub-directories we want to copy into it:
     os.makedirs(dest, exist_ok=True)
@@ -119,14 +122,16 @@ def create_profile():
         else:
             shutil.copy2(src_file, dest_file)
 
+    print('Writing labconfig file')
     make_labconfig_file(args.apparatus_name)
-        
+
     # rename apparatus directories
     if args.apparatus_name is not None:
+        print('\tRenaming apparatus directories')
         for path in dest.glob('**/example_apparatus/'):
             new_path = Path(str(path).replace('example_apparatus', args.apparatus_name))
             path.rename(new_path)
 
     if args.compile:
-        # compile the initial example connection table
+        print('Compiling the example connection table')
         compile_connection_table()

--- a/labscript_profile/create.py
+++ b/labscript_profile/create.py
@@ -96,8 +96,10 @@ def compile_connection_table():
                                        done_callback = dummy_callback)
     print(f'\tOutput written to {output_h5_path}')
 
-def create_profile():
+def create_profile_cli():
     """Function that defines the labscript-profile-create command
+
+    Parses CLI arguments and calls :func:`~.create_profile`.
     """
 
     # capture CMD arguments
@@ -115,6 +117,21 @@ def create_profile():
                         default=False)
     
     args = parser.parse_args()
+
+    create_profile(args.apparatus_name, args.compile)
+
+def create_profile(apparatus_name = None, compile_table = False):
+    """Function that creates a labscript config profile from the default config
+
+    Parameters
+    ----------
+    appratus_name: str, optional
+        apparatus_name to define in the config.
+        If None, defaults to example_apparatus (set in default config file)
+    compile_table: bool, optional
+        Whether to compile to example connection table defined by the default config file
+        Default is False.
+    """
 
     src = Path(DEFAULT_PROFILE_CONTENTS)
     dest = Path(LABSCRIPT_SUITE_PROFILE)
@@ -136,15 +153,15 @@ def create_profile():
             shutil.copy2(src_file, dest_file)
 
     print('Writing labconfig file')
-    make_labconfig_file(args.apparatus_name)
+    make_labconfig_file(apparatus_name)
 
     # rename apparatus directories
-    if args.apparatus_name is not None:
+    if apparatus_name is not None:
         print('\tRenaming apparatus directories')
         for path in dest.glob('**/example_apparatus/'):
-            new_path = Path(str(path).replace('example_apparatus', args.apparatus_name))
+            new_path = Path(str(path).replace('example_apparatus', apparatus_name))
             path.rename(new_path)
 
-    if args.compile:
+    if compile_table:
         print('Compiling the example connection table')
         compile_connection_table()

--- a/labscript_profile/create.py
+++ b/labscript_profile/create.py
@@ -68,9 +68,9 @@ def compile_connection_table():
     config.read(default_labconfig_path())
 
     # The path to the user's connection_table.py script
-    script_path = config['paths']['connection_table_py']
+    script_path = os.path.expandvars(config['paths']['connection_table_py'])
     # path to the connection_table.h5 destination
-    output_h5_path = config['paths']['connection_table_h5']
+    output_h5_path = os.path.expandvars(config['paths']['connection_table_h5'])
     # create output directory, if needed
     Path(output_h5_path).parent.mkdir(parents=True, exist_ok=True)
     # compile the h5 file

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,4 +69,4 @@ docs = [
 ]
 
 [project.scripts]
-labscript-profile-create = "labscript_profile.create:create_profile"
+labscript-profile-create = "labscript_profile.create:create_profile_cli"


### PR DESCRIPTION
Add command line arguments to the `labscript-profile-create` command that allow for specifying the initial apparatus name and compiling the example connection table that ships with the default profile (populated with dummy components).

This should improve the initial installation process by allowing users to set their own apparatus name when creating their profile and compiling the BLACS connection table and placing it in the default location. Installing from a fresh installation, this allows BLACS to open without any other manual intervention using pure default labconfig options.