### PR TITLE
Remove incorrect and unnecessary attempt to be forward-compatible with vlen strings

### DIFF
--- a/labscript_utils/properties.py
+++ b/labscript_utils/properties.py
@@ -1,4 +1,3 @@
-import sys
 import json
 from base64 import b64encode, b64decode
 from collections.abc import Iterable, Mapping
@@ -121,18 +120,7 @@ def _get_device_properties(h5_file, device_name):
 def _get_con_table_properties(h5_file, device_name):
     import h5py
     dataset = h5_file['connection table']
-
-    # Compare with the name in the connection table
-    # whether it is np.bytes_ or vlenstr:
-    namecol_dtype = dataset.dtype['name']
-    if namecol_dtype.type is np.bytes_:
-        device_name = device_name.encode('utf8')
-    elif namecol_dtype is h5py.special_dtype(vlen=str):
-        pass
-    else:
-        raise TypeError(namecol_dtype)
-
-    row = dataset[dataset['name'] == device_name][0]
+    row = dataset[dataset['name'] == device_name.encode('utf8')][0]
     json_string = row['properties']
     return deserialise(json_string)
 
@@ -140,18 +128,7 @@ def _get_con_table_properties(h5_file, device_name):
 def _get_unit_conversion_parameters(h5_file, device_name):
     import h5py
     dataset = h5_file['connection table']
-
-    # Compare with the name in the connection table
-    # whether it is np.bytes_ or vlenstr:
-    namecol_dtype = dataset.dtype['name']
-    if namecol_dtype.type is np.bytes_:
-        device_name = device_name.encode('utf8')
-    elif namecol_dtype is h5py.special_dtype(vlen=str):
-        pass
-    else:
-        raise TypeError(namecol_dtype)
-
-    row = dataset[dataset['name'] == device_name][0]
+    row = dataset[dataset['name'] == device_name.encode('utf8')][0]
     json_string = row['unit conversion params']
     return deserialise(json_string)
 


### PR DESCRIPTION
Looks like I was confused when I originally wrote this, and thought that data read from vlen string datasets would come back as unicode strings - but it's actually still byestrings.

Two bugs:
* `namecol_dtype is h5py.special_dtype(vlen=str)` is always `False` because of the `is` comparison - even when the dtype is a vlen string, that dtype object isn't a singleton, so an `==` check would be needed.
* vlen strings within datasets (as opposed to attributes) are still of `bytes` type, so comparison with `device_name` still requires encoding the latter.

Since the code should be encoding the device name regardless of whether it's fixed length or vlen, the check and if statement can be removed altogether.

This change does exactly nothing given that the name field of connection tables is still fixed-length. But now it correctly allows for that to change in the future (which we shouldn't do immediately so that older labscript_utils installs can still read newly-compiled shot files, for a time).

(I tried to change this today in https://github.com/labscript-suite/labscript/pull/122, but this bug stopped me)