### PR TITLE
Mac os icon

### DIFF
--- a/labscript_utils/splash.py
+++ b/labscript_utils/splash.py
@@ -39,6 +39,39 @@ if QT_ENV == 'PyQt5':
     QtWidgets.QApplication.setAttribute(Qt.AA_UseHighDpiPixmaps, True)
 
 
+def configure_qapplication(qapplication):
+    """Apply labscript-wide QApplication configuration."""
+    qapplication.setAttribute(Qt.AA_DontShowIconsInMenus, False)
+    if sys.platform == 'darwin':
+        icon_path = qapplication.property('_labscript_icon_path')
+        if icon_path:
+            icon = QtGui.QIcon(icon_path)
+            if not icon.isNull():
+                qapplication.setWindowIcon(icon)
+        if qapplication.property('_labscript_qapplication_configured'):
+            return qapplication
+        # Native macOS widget styling makes many Qt controls look inconsistent
+        # with the rest of the suite. Use Qt's own style, but preserve the
+        # current palette so dark/light appearance still follows the active
+        # theme.
+        palette = QtGui.QPalette(qapplication.palette())
+        style = QtWidgets.QStyleFactory.create('Fusion')
+        if style is not None:
+            qapplication.setStyle(style)
+            qapplication.setPalette(palette)
+    elif qapplication.property('_labscript_qapplication_configured'):
+        return qapplication
+    qapplication.setProperty('_labscript_qapplication_configured', True)
+    return qapplication
+
+
+def get_qapplication(argv=None):
+    qapplication = QtWidgets.QApplication.instance()
+    if qapplication is None:
+        qapplication = QtWidgets.QApplication(sys.argv if argv is None else argv)
+    return configure_qapplication(qapplication)
+
+
 class Splash(QtWidgets.QFrame):
     w = 250
     h = 230
@@ -50,9 +83,9 @@ class Splash(QtWidgets.QFrame):
     FG = '#000000'
 
     def __init__(self, imagepath):
-        self.qapplication = QtWidgets.QApplication.instance()
-        if self.qapplication is None:
-            self.qapplication = QtWidgets.QApplication(sys.argv)
+        self.qapplication = get_qapplication()
+        self.qapplication.setProperty('_labscript_icon_path', imagepath)
+        configure_qapplication(self.qapplication)
         super().__init__()
         self.icon = QtGui.QPixmap()
         self.icon.load(imagepath)

--- a/labscript_utils/splash.py
+++ b/labscript_utils/splash.py
@@ -65,13 +65,6 @@ def configure_qapplication(qapplication):
     return qapplication
 
 
-def get_qapplication(argv=None):
-    qapplication = QtWidgets.QApplication.instance()
-    if qapplication is None:
-        qapplication = QtWidgets.QApplication(sys.argv if argv is None else argv)
-    return configure_qapplication(qapplication)
-
-
 class Splash(QtWidgets.QFrame):
     w = 250
     h = 230
@@ -83,7 +76,9 @@ class Splash(QtWidgets.QFrame):
     FG = '#000000'
 
     def __init__(self, imagepath):
-        self.qapplication = get_qapplication()
+        self.qapplication = QtWidgets.QApplication.instance()
+        if self.qapplication is None:
+            self.qapplication = QtWidgets.QApplication(sys.argv)
         self.qapplication.setProperty('_labscript_icon_path', imagepath)
         configure_qapplication(self.qapplication)
         super().__init__()

--- a/labscript_utils/splash.py
+++ b/labscript_utils/splash.py
@@ -43,10 +43,6 @@ def configure_qapplication(qapplication):
     """Apply labscript-wide QApplication configuration."""
     qapplication.setAttribute(Qt.AA_DontShowIconsInMenus, False)
     if sys.platform == 'darwin':
-        application_name = qapplication.property('_labscript_application_name')
-        if application_name:
-            qapplication.setApplicationName(application_name)
-            qapplication.setApplicationDisplayName(application_name)
         icon_path = qapplication.property('_labscript_icon_path')
         if icon_path:
             icon = QtGui.QIcon(icon_path)
@@ -68,7 +64,6 @@ def configure_qapplication(qapplication):
     qapplication.setProperty('_labscript_qapplication_configured', True)
     return qapplication
 
-
 class Splash(QtWidgets.QFrame):
     w = 250
     h = 230
@@ -80,15 +75,14 @@ class Splash(QtWidgets.QFrame):
     FG = '#000000'
 
     def __init__(self, imagepath, application_name=None):
-        if application_name is not None:
-            QtCore.QCoreApplication.setApplicationName(application_name)
-            QtGui.QGuiApplication.setApplicationDisplayName(application_name)
         self.qapplication = QtWidgets.QApplication.instance()
         if self.qapplication is None:
-            self.qapplication = QtWidgets.QApplication(sys.argv)
+            argv = sys.argv
+            if application_name is not None:
+                # Create a new argv so QApplication can alter it without mutating sys.argv.
+                argv = [application_name] + argv[1:]
+            self.qapplication = QtWidgets.QApplication(argv)
         self.qapplication.setProperty('_labscript_icon_path', imagepath)
-        if application_name is not None:
-            self.qapplication.setProperty('_labscript_application_name', application_name)
         configure_qapplication(self.qapplication)
         super().__init__()
         self.icon = QtGui.QPixmap()

--- a/labscript_utils/splash.py
+++ b/labscript_utils/splash.py
@@ -11,7 +11,9 @@
 #                                                                   #
 #####################################################################
 
+import json
 import sys
+from pathlib import Path
 from labscript_utils import dedent
 
 try:
@@ -45,7 +47,23 @@ def configure_qapplication(qapplication):
     if sys.platform == 'darwin':
         icon_path = qapplication.property('_labscript_icon_path')
         if icon_path:
-            icon = QtGui.QIcon(icon_path)
+            icon_path = Path(icon_path)
+            try:
+                config = json.loads(
+                    (icon_path.parent / 'desktop-app.json').read_text(encoding='utf8')
+                )
+            except (OSError, json.JSONDecodeError):
+                application_name = None
+            else:
+                module_config = config.get('modules', {}).get(icon_path.stem, {})
+                application_name = (
+                    module_config.get('short_display_name')
+                    or module_config.get('display_name')
+                )
+            if application_name:
+                qapplication.setApplicationName(application_name)
+                qapplication.setApplicationDisplayName(application_name)
+            icon = QtGui.QIcon(str(icon_path))
             if not icon.isNull():
                 qapplication.setWindowIcon(icon)
         if qapplication.property('_labscript_qapplication_configured'):

--- a/labscript_utils/splash.py
+++ b/labscript_utils/splash.py
@@ -74,7 +74,7 @@ class Splash(QtWidgets.QFrame):
     BG = '#ffffff'
     FG = '#000000'
 
-    def __init__(self, imagepath, application_name=None):
+    def __init__(self, icon_path, application_name=None):
         self.qapplication = QtWidgets.QApplication.instance()
         if self.qapplication is None:
             argv = sys.argv
@@ -82,13 +82,13 @@ class Splash(QtWidgets.QFrame):
                 # Create a new argv so QApplication can alter it without mutating sys.argv.
                 argv = [application_name] + argv[1:]
             self.qapplication = QtWidgets.QApplication(argv)
-        self.qapplication.setProperty('_labscript_icon_path', imagepath)
+        self.qapplication.setProperty('_labscript_icon_path', icon_path)
         configure_qapplication(self.qapplication)
         super().__init__()
         self.icon = QtGui.QPixmap()
-        self.icon.load(imagepath)
+        self.icon.load(icon_path)
         if self.icon.isNull():
-            raise ValueError("Invalid image file: {}.\n".format(imagepath))
+            raise ValueError("Invalid image file: {}.\n".format(icon_path))
         self.icon = self.icon.scaled(
             self.imwidth, self.imheight, Qt.AspectRatioMode.KeepAspectRatio, Qt.TransformationMode.SmoothTransformation
         )

--- a/labscript_utils/splash.py
+++ b/labscript_utils/splash.py
@@ -11,9 +11,7 @@
 #                                                                   #
 #####################################################################
 
-import json
 import sys
-from pathlib import Path
 from labscript_utils import dedent
 
 try:
@@ -45,25 +43,13 @@ def configure_qapplication(qapplication):
     """Apply labscript-wide QApplication configuration."""
     qapplication.setAttribute(Qt.AA_DontShowIconsInMenus, False)
     if sys.platform == 'darwin':
+        application_name = qapplication.property('_labscript_application_name')
+        if application_name:
+            qapplication.setApplicationName(application_name)
+            qapplication.setApplicationDisplayName(application_name)
         icon_path = qapplication.property('_labscript_icon_path')
         if icon_path:
-            icon_path = Path(icon_path)
-            try:
-                config = json.loads(
-                    (icon_path.parent / 'desktop-app.json').read_text(encoding='utf8')
-                )
-            except (OSError, json.JSONDecodeError):
-                application_name = None
-            else:
-                module_config = config.get('modules', {}).get(icon_path.stem, {})
-                application_name = (
-                    module_config.get('short_display_name')
-                    or module_config.get('display_name')
-                )
-            if application_name:
-                qapplication.setApplicationName(application_name)
-                qapplication.setApplicationDisplayName(application_name)
-            icon = QtGui.QIcon(str(icon_path))
+            icon = QtGui.QIcon(icon_path)
             if not icon.isNull():
                 qapplication.setWindowIcon(icon)
         if qapplication.property('_labscript_qapplication_configured'):
@@ -93,11 +79,16 @@ class Splash(QtWidgets.QFrame):
     BG = '#ffffff'
     FG = '#000000'
 
-    def __init__(self, imagepath):
+    def __init__(self, imagepath, application_name=None):
+        if application_name is not None:
+            QtCore.QCoreApplication.setApplicationName(application_name)
+            QtGui.QGuiApplication.setApplicationDisplayName(application_name)
         self.qapplication = QtWidgets.QApplication.instance()
         if self.qapplication is None:
             self.qapplication = QtWidgets.QApplication(sys.argv)
         self.qapplication.setProperty('_labscript_icon_path', imagepath)
+        if application_name is not None:
+            self.qapplication.setProperty('_labscript_application_name', application_name)
         configure_qapplication(self.qapplication)
         super().__init__()
         self.icon = QtGui.QPixmap()


### PR DESCRIPTION
This fixes two MacOS specific issues.  First using the QT "MacOS native-style" widgets did not preserve the layout present in windows or linux, so we ask for the "fusion" widgets.  The runmanager tabs specifically did not get the desired stacking behavior to the left of the tabs (and many other things looked bad).

Second the mac desktop apps did not get icons in the dock (they were just generic place holders).

This patches labscript_utils.splash with macos specific updates to fix these problems.  

There is a Lyse partner to this pull request.